### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 name: build
 
-permissions:
-  contents: read
-
 on:
   release:
     types:
       - published
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 
 on:
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: build
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/Gaardsholt/vscode-whatthecommit/security/code-scanning/4](https://github.com/Gaardsholt/vscode-whatthecommit/security/code-scanning/4)

To fix this problem, you should add a `permissions` block to the workflow file `.github/workflows/build.yml` at either the root (workflow) level or within the `build` job. Setting it at the job level is sufficient, but setting it at the workflow level will apply to all jobs, which is preferred in single-job workflows. The least-privilege starting point is `contents: read`, which allows the workflow to read repository contents but blocks write operations using the GITHUB_TOKEN. No steps need to push code or use GITHUB_TOKEN for publishing, so no raise in privilege is needed. Add the following block after the `name:` line and before `on:`, or directly under the job if per-job permissions are needed.

**Region to change:**  
Insert `permissions:` at the top of `.github/workflows/build.yml`, after the workflow name if top-level, like so:
```yaml
name: build
permissions:
  contents: read
```

**Methods/Imports/Definitions needed:**  
No new imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
