### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,9 @@
 name: Release Drafter
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   push:
     # branches to consider in the event; optional, defaults to all


### PR DESCRIPTION
Potential fix for [https://github.com/Gaardsholt/vscode-whatthecommit/security/code-scanning/2](https://github.com/Gaardsholt/vscode-whatthecommit/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block to the workflow, applying least privilege principles. This can be set either at the workflow root (to apply to all jobs) or at the job level (for individual jobs). Since there is only one job, either location suffices. For Release Drafter, it generally needs `contents: write` to drafts/releases and, if you use autolabeling, `pull-requests: write`. We do see pull request events and "release drafter" being run, so set:

```yaml
permissions:
  contents: write
  pull-requests: write
```

Add this block above `jobs:` or inside the `update_release_draft` job. For clarity and future extensibility, it's best to add it at the workflow root, just after the workflow name. No additional imports or definitions are needed for a YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
