### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -8,10 +8,11 @@ on:
     # At 13:37 on day-of-month 7.
     - cron: '37 13 7 * *'
 
+permissions:
+  contents: write
+
 jobs:
   release:
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: cardinalby/git-get-release-action@v1

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: cardinalby/git-get-release-action@v1


### PR DESCRIPTION
Potential fix for [https://github.com/Gaardsholt/vscode-whatthecommit/security/code-scanning/1](https://github.com/Gaardsholt/vscode-whatthecommit/security/code-scanning/1)

To fix the problem, the workflow needs to explicitly specify the required minimal permissions for the job or at the workflow root level. For a release/publishing workflow, write access to `contents` (for creating releases/tags) is typically required, while other permissions should remain as restrictive as possible.  
**Best way to fix:**  
- Add a `permissions` block specifying at least `contents: write` (could also limit this more if known, e.g., if only releases are being affected, but most release actions require `contents: write`).  
- Add this block at the job level (under `release:`) so it's clear and scoped to the relevant job, or at the workflow root if all jobs need the same access. Since there is only one job here, both are equivalent, but job-level is often clearer.

**Needed changes:**  
- At line 13, before `runs-on: ubuntu-latest`, insert:
  ```yaml
  permissions:
    contents: write
  ```
  This will restrict the job's permissions as recommended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
